### PR TITLE
fix: correct tagManager route component path casing

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     {
       name: '标签',
       path: '/tagManager',
-      component: './TagManager/index',
+      component: './tagManager/index',
     },
     {
       path: '/user',


### PR DESCRIPTION
### Motivation
- Resolve build error `MODULE_NOT_FOUND` caused by an incorrect route component path casing in the Umi configuration on case-sensitive filesystems.

### Description
- Update `/.umirc.ts` to change the `/tagManager` route component from `component: './TagManager/index'` to `component: './tagManager/index'` to match the actual directory name.

### Testing
- Ran `npm run build` and confirmed the build completed successfully and the previous `MODULE_NOT_FOUND` error is gone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002d8584f4832eb88436f4468a09f8)